### PR TITLE
Question of the day

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **.DS_Store
 secrets.sh
 .vscode/*
+data/openai.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/main.py
+++ b/main.py
@@ -6,12 +6,17 @@ from src.constants import MensaNames, MensaURL
 from src.scraping import get_menus
 from src.utils import print_menu
 from src.weather import get_weather
+from src.question import get_random_question
 
 
 def main(args):
     menu_df = get_menus()
+    question = get_random_question(0 if args.time == "mittag" else 1)
 
     print_welcome_message(args)
+    if question is not None:
+        print("❓ " + question[0])
+    print() 
 
     menu_per_mensa = menu_df.groupby("mensa")
 
@@ -34,6 +39,8 @@ def main(args):
         print_menu(f"{idx}: {mensa_name}", menu_per_mensa.get_group(mensa_name))
         idx += 1
 
+    if question is not None:
+        print("❗ " + question[1])
 
 def print_welcome_message(args):
     # with open("data/messages.json", "r") as f:
@@ -52,7 +59,7 @@ def print_welcome_message(args):
     hour = 12 if args.time == "mittag" else 18
     temperature, emoji = get_weather(8001, hour)
 
-    print(f"Today is {day} ({emoji}, {int(temperature)} °C) and here is today's menu:\n")
+    print(f"Today is {day} ({emoji}, {int(temperature)} °C) and here is today's menu:")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from src.question import get_random_question
 
 def main(args):
     menu_df = get_menus()
-    question = get_random_question(0 if args.time == "mittag" else 1)
+    question = get_random_question()
 
     print_welcome_message(args)
     if question is not None:

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ def main(args):
 
     print_welcome_message(args)
     if question is not None:
-        print("❓ " + question[0])
+        print("🧠 " + question[0])
     print() 
 
     menu_per_mensa = menu_df.groupby("mensa")
@@ -40,7 +40,7 @@ def main(args):
         idx += 1
 
     if question is not None:
-        print("❗ " + question[1])
+        print("💡 " + question[1])
 
 def print_welcome_message(args):
     # with open("data/messages.json", "r") as f:

--- a/src/question.py
+++ b/src/question.py
@@ -1,4 +1,3 @@
-from openai import OpenAI
 from datetime import datetime, timedelta
 import json
 import requests
@@ -15,6 +14,8 @@ def get_random_question(top_n=25):
 
     if "api_key" not in cfg or len(cfg["api_key"]) == 0:
         return None
+
+    from openai import OpenAI
 
     client = OpenAI(api_key=cfg["api_key"])
 

--- a/src/question.py
+++ b/src/question.py
@@ -49,8 +49,8 @@ def get_random_question(top_n=25):
             if is_article:
                 topics.append(title)
 
-    # Pick from the n-th most viewed article a title as our topic
-    topic = random.choice(topics)
+    # Pick from the n-th most viewed articles a title as our topic
+    topic = random.choice(topics[:top_n])
 
     response = client.chat.completions.create(
         model="gpt-3.5-turbo",
@@ -71,6 +71,8 @@ def get_random_question(top_n=25):
     )
 
     choice = response.choices[0].message.content
-    response = json.loads(choice)
-
-    return (response["question"], response["answer"])
+    try:
+        response = json.loads(choice)
+        return (response["question"], response["answer"])
+    except:
+        return None

--- a/src/question.py
+++ b/src/question.py
@@ -1,0 +1,75 @@
+from openai import OpenAI
+from datetime import datetime, timedelta
+import json
+import requests
+import random
+import os
+
+
+def get_random_question(top_n=25):
+    if not os.path.exists("data/openai.json"):
+        return None
+
+    with open("data/openai.json", "r") as f:
+        cfg = json.load(f)
+
+    if "api_key" not in cfg or len(cfg["api_key"]) == 0:
+        return None
+
+    client = OpenAI(api_key=cfg["api_key"])
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/118.0"}
+
+    # Get the current Wikipedia namespaces that we want to ignore (for example user accounts or the search)
+    query = requests.get(f"https://en.wikipedia.org/w/api.php?action=query&meta=siteinfo&siprop=namespaces%7Cnamespacealiases&formatversion=2&format=json",
+                         headers=headers).json()["query"]
+    namespaces = []
+    for ns in query["namespaces"]:
+        namespaces.append(query["namespaces"][ns]["name"])
+    for na in query["namespacealiases"]:
+        namespaces.append(na["alias"])
+
+    topics = []
+    for days in range(0, 5):
+        # Get the most viewed articles `days` days ago
+        date = (datetime.now() - timedelta(days)).strftime("%Y/%m/%d")
+        response = requests.get(f"https://wikimedia.org/api/rest_v1/metrics/pageviews/top/en.wikipedia/all-access/" + date,
+                                headers=headers)
+        if response.status_code != 200:
+            continue
+
+        articles = response.json()["items"][0]["articles"]
+        for a in articles:
+            title = a["article"].replace("_", " ")
+            # Main page usually has most views
+            is_article = title != "Main Page" and not any(
+                title.startswith(ns + ":") for ns in namespaces)
+            if is_article:
+                topics.append(title)
+
+    # Pick from the n-th most viewed article a title as our topic
+    topic = random.choice(topics)
+
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {
+                "role": "system",
+                "content": "You are given a topic and should pick one and write a challenging question." +
+                "Keep it very short and concise. Provide it as JSON with keys question and answer."
+            },
+            {
+                "role": "user",
+                "content": topic
+            },
+        ],
+        n=1,
+        temperature=1,
+        max_tokens=256
+    )
+
+    choice = response.choices[0].message.content
+    response = json.loads(choice)
+
+    return (response["question"], response["answer"])


### PR DESCRIPTION
Adds a question of the day at the beginning of the menu with the answer at the end of the menu.

* Queries the top 25 articles of the day on Wikipedia using their API
* Asks OpenAI's GPT 3.5 Turbo via API to provide a question and answer for a random article, given only the article's title
* Only the title is given to save tokens (and thus money)

The answers that GPT provides might sometimes be wrong, but I think this adds some charm to it.

The script checks for an API key in the `data/openai.json` (which is git ignored). If the file does not exist or the key is not specified, the script will not add a question of the day. If you want to use this feature, you must `pip install openai`, but the import is done only after checking for the key, so it is optional.

Sample `data/openai.json`:
```json
{
    "api_key": "sk-YOURKEY"
}
```

Sample output:

```
Today is freitag (⛅, 6 °C) and here is today's menu:
🧠 What movie did Glen Powell star in alongside Tom Cruise?

[MENU]

💡 Top Gun: Maverick
```

